### PR TITLE
11ty Builds Hotfix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ name: Deploy Eleventy Site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"] # Or your default branch (e.g., master)
+    branches: ["main"] # Updated to main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -45,8 +45,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload the output directory from the build step
-          path: './blog/_site' # Specify the correct build output path
+          # Upload the final combined directory from the build step
+          path: './_final_site' # Changed from ./blog/_site
 
   # Deployment job
   deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ blog/node_modules/
 # Ignore Eleventy build output directory
 blog/_site/
 
+# Ignore final combined site build directory
+_final_site/
+
 # DO NOT ignore the root /blog directory (built site)
 
 # Editor/IDE specific files

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@ blog/_site/
 # Ignore final combined site build directory
 _final_site/
 
-# DO NOT ignore the root /blog directory (built site)
-
 # Editor/IDE specific files
 .vscode/
 .idea/

--- a/blog/package.json
+++ b/blog/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "env ELEVENTY_ENV=development npx @11ty/eleventy --serve",
-    "build": "npm run build:site",
-    "build:site": "env ELEVENTY_ENV=production npx @11ty/eleventy"
+    "build:site": "env ELEVENTY_ENV=production npx @11ty/eleventy",
+    "build": "rm -rf ../_final_site && mkdir -p ../_final_site/blog && cp ../index.html ../_final_site/ && cp -R ../css ../_final_site/ && cp -R ../js ../_final_site/ && cp -R ../images ../_final_site/ && cp ../CNAME ../_final_site/ && npm run build:site && cp -R ./_site/. ../_final_site/blog/"
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",

--- a/blog/package.json
+++ b/blog/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "env ELEVENTY_ENV=development npx @11ty/eleventy --serve",
     "build:site": "env ELEVENTY_ENV=production npx @11ty/eleventy",
-    "build": "rm -rf ../_final_site && mkdir -p ../_final_site/blog && cp ../index.html ../_final_site/ && cp -R ../css ../_final_site/ && cp -R ../js ../_final_site/ && cp -R ../images ../_final_site/ && cp ../CNAME ../_final_site/ && npm run build:site && cp -R ./_site/. ../_final_site/blog/"
+    "build": "node ../scripts/build.js"
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,77 @@
+const fs = require('fs').promises;
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Define paths relative to the script location (website/scripts/)
+const projectRoot = path.join(__dirname, '..'); // website/
+const blogDir = path.join(projectRoot, 'blog'); // website/blog/
+const blogSourceDir = path.join(blogDir, 'src'); // website/blog/src/
+const blogOutputDir = path.join(blogDir, '_site'); // website/blog/_site/
+const finalOutputDir = path.join(projectRoot, '_final_site'); // website/_final_site/
+
+// Items to ignore when copying from the root directory
+const ignoreList = [
+  '.git',
+  'node_modules', // Ignore root node_modules if any
+  'blog', // Ignore the entire blog source/build directory
+  '_final_site', // Ignore the output directory itself
+  '.github',
+  'scripts', // Ignore the scripts directory
+  '.DS_Store',
+  '.gitignore',
+  'README.md',
+  'package.json', // Assuming root package.json is not for deployment
+  'package-lock.json',
+  // Add any other files/folders at the root that shouldn't be deployed
+];
+
+async function build() {
+  try {
+    console.log('Starting build process...');
+
+    // 1. Clean up old output directories
+    console.log(`Removing old directories: ${finalOutputDir} and ${blogOutputDir}`);
+    await fs.rm(finalOutputDir, { recursive: true, force: true });
+    await fs.rm(blogOutputDir, { recursive: true, force: true }); // Clean blog output too
+
+    // 2. Create final output structure
+    console.log(`Creating output structure: ${finalOutputDir}/blog`);
+    await fs.mkdir(path.join(finalOutputDir, 'blog'), { recursive: true });
+
+    // 3. Run Eleventy build
+    console.log('Running Eleventy build (npm run build:site)...');
+    // Execute from the blog directory
+    execSync('npm run build:site', { cwd: blogDir, stdio: 'inherit' });
+    console.log('Eleventy build complete.');
+
+    // 4. Copy root files/folders
+    console.log(`Copying root files from ${projectRoot} to ${finalOutputDir}`);
+    const rootEntries = await fs.readdir(projectRoot, { withFileTypes: true });
+
+    for (const entry of rootEntries) {
+      if (!ignoreList.includes(entry.name)) {
+        const sourcePath = path.join(projectRoot, entry.name);
+        const destPath = path.join(finalOutputDir, entry.name);
+        console.log(`  - Copying ${entry.name}...`);
+        await fs.cp(sourcePath, destPath, { recursive: true });
+      } else {
+        console.log(`  - Ignoring ${entry.name}`);
+      }
+    }
+    console.log('Root file copy complete.');
+
+    // 5. Copy Eleventy build output to final destination
+    console.log(`Copying Eleventy output from ${blogOutputDir} to ${path.join(finalOutputDir, 'blog')}`);
+    await fs.cp(blogOutputDir, path.join(finalOutputDir, 'blog'), { recursive: true });
+    console.log('Eleventy output copy complete.');
+
+    console.log('Build process finished successfully!');
+
+  } catch (error) {
+    console.error('Build process failed:', error);
+    process.exit(1); // Exit with error code
+  }
+}
+
+// Run the build function
+build(); 


### PR DESCRIPTION
Notes: Paths are fun! I really could have saved myself the headache by moving my entire site into 11ty, but (for now) I still want to keep 11ty detached from the existing plain site. However, as I discovered quickly, this makes automating the build and deployments a bit tricky. 

Hotfix: 

- Copy root website files directly into the clean _final_site directory. 
- _final_site will contain my root (non-blog) website pages
- Then the 11ty build, which creates blog/_site.
- Finally, copy the contents of blog/_site into a blog subdirectory within the final output folder (_final_site/blog/)
- 🚀 🚀 🚀 

TODO: Validate builds and deployment are working as intended after merging. 

Nit: A long overdue rename of `master` -> `main` for the entire repo ❤️ 